### PR TITLE
Add missing PyICU dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ gensim==0.12.4
 lxml==3.5.0
 nltk==3.2
 numpy==1.10.4
+PyICU==1.9.2
 scikit-learn==0.17.1
 tqdm==3.8.0
 word2vec==0.9.1


### PR DESCRIPTION
Library used to remove accents in text was missing in `requirements.txt` file.